### PR TITLE
feat: 게시글 좋아요 수 및 날짜 기준 정렬 기능 구현

### DIFF
--- a/app/templates/app/gallery.html
+++ b/app/templates/app/gallery.html
@@ -13,11 +13,15 @@
     <h2>{% if gallery_type == 'personal' %}내 갤러리{% else %}공개 갤러리{% endif %}</h2>
 
     <form method="get" class="mb-4">
-        <div class="input-group">
+        <div class="d-flex gap-2">
             <input type="text" name="search" class="form-control" placeholder="제목으로 검색" value="{{ search_query }}">
             {% if selected_tag %}
             <input type="hidden" name="tag" value="{{ selected_tag }}">
             {% endif %}
+            <select name="sort" class="form-select" style="max-width: 150px;">
+                <option value="date" {% if sort_by == 'date' %}selected{% endif %}>최신순</option>
+                <option value="likes" {% if sort_by == 'likes' %}selected{% endif %}>좋아요순</option>
+            </select>
             <button type="submit" class="btn btn-primary">검색</button>
         </div>
         <div class="tag-buttons mt-2">
@@ -31,6 +35,8 @@
                 태그 초기화
             </a>
             {% endif %}
+        </div>
+            </div>
         </div>
     </form>
 

--- a/app/views.py
+++ b/app/views.py
@@ -547,7 +547,7 @@ from django.template.loader import render_to_string
 def my_gallery(request):
     search_query = request.GET.get("search", "")
     tag_filter = request.GET.get("tag", "")
-    sort_by = request.GET.get("sort", "likes")
+    sort_by = request.GET.get("sort", "date")
 
     posts_qs = Post.objects.filter(user=request.user).annotate(like_count=Count('likes'))
     
@@ -561,12 +561,12 @@ def my_gallery(request):
 
     
     if tag_filter:
-        all_posts = list(posts_qs.order_by("-date_posted"))
+        all_posts = list(posts_qs)
         posts_list = [
             post for post in all_posts if post.tags and tag_filter in post.tags
         ]
     else:
-        posts_list = list(posts_qs.order_by("-date_posted"))
+        posts_list = list(posts_qs)
 
     page = int(request.GET.get("page", "1"))
     post_cnt = 9
@@ -617,15 +617,14 @@ def public_gallery(request):
         posts_qs = posts_qs.order_by('-date_posted')
 
     if tag_filter:
-        # __contains 대신 파이썬 리스트 필터링 수행
-        all_posts = list(posts_qs.order_by("-date_posted"))
+        all_posts = list(posts_qs)
         posts_list = [
             post for post in all_posts if post.tags and tag_filter in post.tags
         ]
         posts = posts_list[offset : offset + post_cnt]
         total_count = len(posts_list)
     else:
-        posts = posts_qs.order_by("-date_posted")[offset : offset + post_cnt]
+        posts = posts_qs[offset : offset + post_cnt]
 
     has_more = (offset + post_cnt) < total_count
 


### PR DESCRIPTION
- 내 갤러리 기본 정렬을 최신순으로 설정
- 공개 갤러리 기본 정렬을 좋아요순으로 설정
- 두 갤러리 모두 날짜/좋아요순 정렬 옵션 추가
- 더보기 시에도 정렬 순서 유지되도록 페이징 로직 수정